### PR TITLE
Feature/add date issued to gift cards/165748876

### DIFF
--- a/app/models/spree/gift_card.rb
+++ b/app/models/spree/gift_card.rb
@@ -176,6 +176,10 @@ module Spree
       %w[checkout pending].include?(payment.state)
     end
 
+    def date_issued
+      created_at.strftime("%d/%m/%Y %I:%M %p")
+    end
+
     private
 
     def redeem(user)

--- a/app/views/spree/admin/gift_cards/index.html.erb
+++ b/app/views/spree/admin/gift_cards/index.html.erb
@@ -23,6 +23,7 @@
       <th><%= Spree.t(:sender_email) %></th>
       <th><%= Spree.t(:sender_name) %></th>
       <th><%= Spree.t(:note) %></th>
+      <th><%= Spree.t(:date_issued) %></th>
       <th class="actions" width="100"></th>
     </tr>
   </thead>
@@ -38,6 +39,7 @@
         <td><%= card.sender_email %></td>
         <td><%= card.sender_name %></td>
         <td><%= card.note %></td>
+        <td><%= card.date_issued %></td>
         <td class="actions">
           <%= link_to_edit card, no_text: true if can?(:edit, card) %>
           &nbsp;


### PR DESCRIPTION
Adding the `date_issued` method and column to Spree admin index page to display gift card creation dates.